### PR TITLE
画像表示周りと起動画面切り替え実装

### DIFF
--- a/lib/interfaces/message_interface.dart
+++ b/lib/interfaces/message_interface.dart
@@ -3,5 +3,5 @@ import 'package:chat_flutter/model/message.dart';
 abstract class MessageInterface {
   Future<void> sendMessage(String text, String roomId, String senderId);
 
-  Stream<List<Message>> getMessage(String roomId,String userId);
+  Stream<List<Message>> getMessage(String roomId, String userId);
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,14 +44,16 @@ class Wrapped extends StatelessWidget {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<Object>(
-      future: Provider.of<Authenticator>(context).getUid(),
+    return FutureBuilder<String>(
+      future: Provider.of<ProfileController>(context,listen: false).getUserById(),
       builder: (context, snapshot) {
         if(snapshot.connectionState==ConnectionState.waiting){
-          return Container();
-        }
-        if(snapshot.data!=''){
-          Provider.of<ProfileController>(context).getUserById();
+          return Container(
+            color: Colors.white,
+            child: const Center(
+              child: CircularProgressIndicator(),
+            ),
+          );
         }
         return MaterialApp(
           title: 'Flutter Demo',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,14 +22,13 @@ void main() {
         create: (_) => MessageService(),
       ),
     ],
-    child: MyApp(),
+    child: Wrapped(),
   ));
 }
 
-class MyApp extends StatelessWidget {
+class Wrapped extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    // Authenticatorをコンストラクタで渡したかったので、MultiProviderではできなかった
     return ChangeNotifierProvider(
       create: (_) => ProfileController(
         Provider.of<Authenticator>(
@@ -37,31 +36,49 @@ class MyApp extends StatelessWidget {
           listen: false,
         ),
       ),
-      child: MaterialApp(
-        title: 'Flutter Demo',
-        theme: ThemeData(
-          primarySwatch: Colors.blue,
-          visualDensity: VisualDensity.adaptivePlatformDensity,
-        ),
-        initialRoute:
-            Provider.of<Authenticator>(context, listen: false).isSignIn.value
-                ? '/homePage'
-                : '/signUpPage',
-        routes: {
-          '/homePage': HomePage.wrapped,
-          '/signUpPage': (context) => SignUpPage.wrapped(
-              Provider.of<Authenticator>(context, listen: false)),
-          '/signInPage': (context) => SignInPage.wrapped(
-              Provider.of<Authenticator>(context, listen: false)),
-          '/roomPage': (context) => RoomPage.wrapped(
-              context, Provider.of<Authenticator>(context, listen: false)),
-          '/profileEditPage': (context) => ProfileEditPage(),
-          '/selectMemberPage': (context) => SelectMemberPage.wrapped(
-              Provider.of<Authenticator>(context, listen: false)),
-          '/createGroupPage': (context) => CreateRoomPage.wrapped(
-              Provider.of<Authenticator>(context, listen: false)),
-        },
-      ),
+      child: MyApp(),
+    );
+  }
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Object>(
+      future: Provider.of<Authenticator>(context).getUid(),
+      builder: (context, snapshot) {
+        if(snapshot.connectionState==ConnectionState.waiting){
+          return Container();
+        }
+        if(snapshot.data!=''){
+          Provider.of<ProfileController>(context).getUserById();
+        }
+        return MaterialApp(
+          title: 'Flutter Demo',
+          theme: ThemeData(
+            primarySwatch: Colors.blue,
+            visualDensity: VisualDensity.adaptivePlatformDensity,
+          ),
+          initialRoute:
+              snapshot.data!=''
+                  ? '/homePage'
+                  : '/signUpPage',
+          routes: {
+            '/homePage': HomePage.wrapped,
+            '/signUpPage': (context) => SignUpPage.wrapped(
+                Provider.of<Authenticator>(context, listen: false)),
+            '/signInPage': (context) => SignInPage.wrapped(
+                Provider.of<Authenticator>(context, listen: false)),
+            '/roomPage': (context) => RoomPage.wrapped(
+                context, Provider.of<Authenticator>(context, listen: false)),
+            '/profileEditPage': (context) => ProfileEditPage(),
+            '/selectMemberPage': (context) => SelectMemberPage.wrapped(
+                Provider.of<Authenticator>(context, listen: false)),
+            '/createGroupPage': (context) => CreateRoomPage.wrapped(
+                Provider.of<Authenticator>(context, listen: false)),
+          },
+        );
+      }
     );
   }
 }

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -16,7 +16,7 @@ class Message {
     this.roomId,
   });
 
-  factory Message.fromJson(Map<String, dynamic> json,String userId) {
+  factory Message.fromJson(Map<String, dynamic> json, String userId) {
     bool judgeIsMe(String senderId) {
       // 自分のIDと比較
       return senderId == userId;

--- a/lib/services/auth/authenticator.dart
+++ b/lib/services/auth/authenticator.dart
@@ -3,10 +3,10 @@ import 'package:rxdart/rxdart.dart';
 
 class Authenticator {
   Authenticator() {
-    _isSignIn.value = firebaseUser.value != null;
+    _isSignIn.value = _firebaseUser.value != null;
     _firebaseAuth.onAuthStateChanged.pipe(_firebaseUser);
     _firebaseAuth.onAuthStateChanged
-        .map((firebaseUser) => firebaseUser != null)
+        .map((firebaseUser) => _firebaseUser != null)
         .pipe(_isSignIn);
   }
 
@@ -50,6 +50,9 @@ class Authenticator {
 
   Future<String> getUid() async {
     final current = await fetchFirebaseUser();
+    if(current==null){
+      return '';
+    }
     return current.uid;
   }
 

--- a/lib/services/firebase_message_service.dart
+++ b/lib/services/firebase_message_service.dart
@@ -11,22 +11,25 @@ class FirebaseMessageService {
       'text': message.text,
       'createdAt': message.sendTime,
     };
-    final updateData = {'lastMessage' : message.text};
+    final updateData = {'lastMessage': message.text};
     await _db
         .collection('message/v1/rooms/${message.roomId}/transcripts')
         .document()
         .setData(messageData);
-    await _db.collection('message/v1/rooms').document('${message.roomId}').updateData(updateData);
+    await _db
+        .collection('message/v1/rooms')
+        .document('${message.roomId}')
+        .updateData(updateData);
   }
 
-  Stream<List<Message>> getMessageData(String roomId,String userId) {
+  Stream<List<Message>> getMessageData(String roomId, String userId) {
     final Stream<QuerySnapshot> querySnapshot = _db
         .collection('message/v1/rooms/$roomId/transcripts')
         .orderBy('createdAt', descending: false)
         .snapshots();
     return querySnapshot.map((snapshot) {
       return snapshot.documents.map((doc) {
-        return Message.fromJson(doc.data,userId);
+        return Message.fromJson(doc.data, userId);
       }).toList();
     });
   }

--- a/lib/services/firebase_room_service.dart
+++ b/lib/services/firebase_room_service.dart
@@ -16,7 +16,7 @@ class FirebaseRoomService {
     return docRef.documentID;
   }
 
-  Future<void> setRoomSetting(String userId, String roomId) async {
+  Future<void> setMyRoomSetting(String userId, String roomId) async {
     final settingData = {
       'allowNotification': false,
     };
@@ -25,22 +25,6 @@ class FirebaseRoomService {
         .collection('message/v1/users/$userId/room_setting')
         .document(roomId)
         .setData(settingData);
-  }
-
-  Stream<List<Future<Room>>> getStreamSnapshot(String uid) {
-    final Stream<QuerySnapshot> querySnapshot =
-        _db.collection('message/v1/users/$uid/room_setting').snapshots();
-    return querySnapshot.map((snapshot) {
-      return snapshot.documents.map((doc) {
-        return _db
-            .collection('message/v1/rooms')
-            .document(doc.documentID)
-            .get()
-            .then((roomDoc) {
-          return Room.fromJson(roomDoc.data, doc.documentID);
-        });
-      }).toList();
-    });
   }
 
   Future<List<Future<Room>>> getMyRoomList(String uid) async {

--- a/lib/services/firebase_user_service.dart
+++ b/lib/services/firebase_user_service.dart
@@ -29,6 +29,12 @@ class FirebaseUserService {
     return User.fromJson(user, uid);
   }
 
+  Future<String> getUserImgUrl(String uid) async {
+    final DocumentSnapshot result =
+        await _db.collection('message/v1/users').document('$uid').get();
+    return result.data['profileImageURL'].toString();
+  }
+
   /*Future<List<User>> getAllUser() async {
     final QuerySnapshot result =
         await _db.collection('message/v1/users').getDocuments();
@@ -39,11 +45,15 @@ class FirebaseUserService {
     }).toList();
   }*/
 
-  Future<List<User>> getSearchedUser(String name) async{
+  Future<List<User>> getSearchedUser(String name) async {
     final startAt = [name];
     final endAt = ['$name\uf8ff'];
-    final QuerySnapshot result =
-        await _db.collection('message/v1/users').orderBy('name').startAt(startAt).endAt(endAt).getDocuments();
+    final QuerySnapshot result = await _db
+        .collection('message/v1/users')
+        .orderBy('name')
+        .startAt(startAt)
+        .endAt(endAt)
+        .getDocuments();
     return result.documents.map((doc) {
       final Map<String, dynamic> user = doc.data;
       return User.fromJson(user, doc.documentID);

--- a/lib/services/message_service.dart
+++ b/lib/services/message_service.dart
@@ -15,7 +15,7 @@ class MessageService implements MessageInterface {
   }
 
   @override
-  Stream<List<Message>> getMessage(String roomId,String userId) {
-    return FirebaseMessageService().getMessageData(roomId,userId);
+  Stream<List<Message>> getMessage(String roomId, String userId) {
+    return FirebaseMessageService().getMessageData(roomId, userId);
   }
 }

--- a/lib/ui/atoms/circular_image.dart
+++ b/lib/ui/atoms/circular_image.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class CircularImage extends StatelessWidget {
+  const CircularImage({Key key, @required this.size, this.imgUrl})
+      : super(key: key);
+  final double size;
+  final String imgUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    if (imgUrl != null && imgUrl.isNotEmpty) {
+      return Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          image: DecorationImage(
+            fit: BoxFit.cover,
+            image: NetworkImage(imgUrl),
+          ),
+        ),
+      );
+    } else {
+      return Container(
+        width: size,
+        height: size,
+        decoration: const BoxDecoration(
+          shape: BoxShape.circle,
+          image: DecorationImage(
+            fit: BoxFit.cover,
+            image: AssetImage('assets/images/avatar.JPG'),
+          ),
+        ),
+      );
+    }
+  }
+}

--- a/lib/ui/atoms/error_dialog.dart
+++ b/lib/ui/atoms/error_dialog.dart
@@ -11,10 +11,10 @@ class ErrorDialog extends StatelessWidget {
       actions: [
         FlatButton(
           child: const Text('OK'),
-          onPressed: (){
+          onPressed: () {
             Navigator.pop(context);
           },
-          ),
+        ),
       ],
     );
   }

--- a/lib/ui/atoms/my_profile_image.dart
+++ b/lib/ui/atoms/my_profile_image.dart
@@ -2,8 +2,8 @@ import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-class ProfileImage extends StatelessWidget {
-  const ProfileImage({Key key, this.size}) : super(key: key);
+class MyProfileImage extends StatelessWidget {
+  const MyProfileImage({Key key, this.size}) : super(key: key);
   final double size;
 
   @override

--- a/lib/ui/molecules/create_room/create_room_list_tile.dart
+++ b/lib/ui/molecules/create_room/create_room_list_tile.dart
@@ -1,5 +1,6 @@
 import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/model/user.dart';
+import 'package:chat_flutter/ui/atoms/circular_image.dart';
 import 'package:flutter/material.dart';
 
 import 'package:chat_flutter/config/app_text_size.dart';
@@ -17,13 +18,9 @@ class CreateRoomListTile extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
-          SizedBox(
-            height: 50,
-            width: 50,
-            child: CircleAvatar(
-              radius: double.infinity,
-              backgroundImage: NetworkImage(user.imgUrl),
-            ),
+          CircularImage(
+            size: 50,
+            imgUrl: user.imgUrl,
           ),
           const SizedBox(
             width: AppSpace.midium,
@@ -31,7 +28,7 @@ class CreateRoomListTile extends StatelessWidget {
           Expanded(
             child: Text(
               user.name,
-              style: TextStyle(
+              style: const TextStyle(
                 fontSize: AppTextSize.midium,
                 fontWeight: FontWeight.bold,
               ),

--- a/lib/ui/molecules/message/message_list_item.dart
+++ b/lib/ui/molecules/message/message_list_item.dart
@@ -1,7 +1,8 @@
 import 'package:chat_flutter/config/app_radius.dart';
 import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/model/message.dart';
-import 'package:chat_flutter/ui/atoms/profile_image.dart';
+import 'package:chat_flutter/services/firebase_user_service.dart';
+import 'package:chat_flutter/ui/atoms/circular_image.dart';
 import 'package:chat_flutter/util/common_func_util.dart';
 import 'package:flutter/material.dart';
 
@@ -12,6 +13,7 @@ class MessageListItem extends StatelessWidget {
   final Message message;
   @override
   Widget build(BuildContext context) {
+    final FirebaseUserService firebaseUserService = FirebaseUserService();
     return Padding(
       padding: const EdgeInsets.all(AppSpace.xsmall),
       child: Row(
@@ -37,8 +39,19 @@ class MessageListItem extends StatelessWidget {
               ],
             ),
           if (!message.isMe)
-            const ProfileImage(
-              size: 40,
+            FutureBuilder<String>(
+              future: firebaseUserService.getUserImgUrl(message.senderId),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const CircularImage(
+                    size: 40,
+                  );
+                }
+                return CircularImage(
+                  size: 40,
+                  imgUrl: snapshot.data,
+                );
+              },
             ),
           Container(
             constraints: BoxConstraints(

--- a/lib/ui/molecules/talk/list_tile.dart
+++ b/lib/ui/molecules/talk/list_tile.dart
@@ -1,5 +1,6 @@
 import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/config/app_text_size.dart';
+import 'package:chat_flutter/ui/atoms/circular_image.dart';
 import 'package:flutter/material.dart';
 import 'package:chat_flutter/model/room.dart';
 
@@ -30,14 +31,7 @@ class TalkPageListTile extends StatelessWidget {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: <Widget>[
-                  SizedBox(
-                    height: 60,
-                    width: 60,
-                    child: CircleAvatar(
-                      radius: double.infinity,
-                      backgroundImage: NetworkImage(snapshot.data.imgUrl),
-                    ),
-                  ),
+                  CircularImage(size: 60, imgUrl: snapshot.data.imgUrl),
                   const SizedBox(
                     width: AppSpace.midium,
                   ),

--- a/lib/ui/pages/create_room/create_room_controller.dart
+++ b/lib/ui/pages/create_room/create_room_controller.dart
@@ -43,7 +43,7 @@ class CreateRoomController with ChangeNotifier {
 
     // メンバー全員のroom_settingを作成(Cloud Functionsで実装する？)
     memberIdList.forEach((userId) async {
-      await _firebaseRoomService.setRoomSetting(userId, roomId);
+      await _firebaseRoomService.setMyRoomSetting(userId, roomId);
     });
   }
 

--- a/lib/ui/pages/create_room/select_member.dart
+++ b/lib/ui/pages/create_room/select_member.dart
@@ -16,8 +16,7 @@ class SelectMemberPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final controller =
-        Provider.of<SelectMemberController>(context);
+    final controller = Provider.of<SelectMemberController>(context);
     final textController = TextEditingController();
     return Scaffold(
       appBar: AppBar(
@@ -50,8 +49,9 @@ class SelectMemberPage extends StatelessWidget {
                 hintText: 'Enter a message',
                 suffixIcon: IconButton(
                   icon: const Icon(Icons.search),
-                  onPressed: () async{
-                    await controller.getSearchedUserExceptMe(textController.text);
+                  onPressed: () async {
+                    await controller
+                        .getSearchedUserExceptMe(textController.text);
                   },
                 ),
               ),

--- a/lib/ui/pages/create_room/select_member_controller.dart
+++ b/lib/ui/pages/create_room/select_member_controller.dart
@@ -4,7 +4,8 @@ import 'package:chat_flutter/services/firebase_user_service.dart';
 import 'package:flutter/material.dart';
 
 class SelectMemberController extends ChangeNotifier {
-  SelectMemberController(this.authenticator); /*{
+  SelectMemberController(this.authenticator);
+  /*{
     getAllUserExceptMe();
   }*/
 
@@ -35,14 +36,13 @@ class SelectMemberController extends ChangeNotifier {
     notifyListeners();
   }*/
 
-  Future<void> getSearchedUserExceptMe(String name) async{
-    final List<User> userList = await FirebaseUserService().getSearchedUser(name);
+  Future<void> getSearchedUserExceptMe(String name) async {
+    final List<User> userList =
+        await FirebaseUserService().getSearchedUser(name);
     final String myId = await authenticator.getUid();
     searchedUserList = userList.where((user) => user.id != myId).toList();
     notifyListeners();
   }
 
-  void searchUser(String id) {
-
-  }
+  void searchUser(String id) {}
 }

--- a/lib/ui/pages/profile/profile.dart
+++ b/lib/ui/pages/profile/profile.dart
@@ -1,6 +1,6 @@
 import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/model/user.dart';
-import 'package:chat_flutter/ui/atoms/profile_image.dart';
+import 'package:chat_flutter/ui/atoms/my_profile_image.dart';
 import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -32,7 +32,7 @@ class _ProfilePage extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          const ProfileImage(
+          const MyProfileImage(
             size: 150,
           ),
           const SizedBox(

--- a/lib/ui/pages/profile/profile_controller.dart
+++ b/lib/ui/pages/profile/profile_controller.dart
@@ -15,14 +15,14 @@ class ProfileController with ChangeNotifier {
   Authenticator authenticator;
   FirebaseUserService firebaseUserService = FirebaseUserService();
 
-  Future<void> getUserById() async {
+  Future<String> getUserById() async {
     final String userId = await authenticator.getUid();
-    print(userId);
     if(userId.isEmpty){
-      return;
+      return '';
     }
     user = await firebaseUserService.getUserData(userId);
     notifyListeners();
+    return 'success';
   }
 
   Future<void> selectProfileImage() async {

--- a/lib/ui/pages/profile/profile_controller.dart
+++ b/lib/ui/pages/profile/profile_controller.dart
@@ -9,9 +9,7 @@ import 'package:chat_flutter/model/user.dart';
 import 'package:image_picker/image_picker.dart';
 
 class ProfileController with ChangeNotifier {
-  ProfileController(this.authenticator) {
-    getUserById();
-  }
+  ProfileController(this.authenticator);
   User user;
   File selectedImageFile;
   Authenticator authenticator;
@@ -19,6 +17,10 @@ class ProfileController with ChangeNotifier {
 
   Future<void> getUserById() async {
     final String userId = await authenticator.getUid();
+    print(userId);
+    if(userId.isEmpty){
+      return;
+    }
     user = await firebaseUserService.getUserData(userId);
     notifyListeners();
   }

--- a/lib/ui/pages/profile/profile_edit.dart
+++ b/lib/ui/pages/profile/profile_edit.dart
@@ -1,9 +1,10 @@
 import 'package:chat_flutter/model/user.dart';
+import 'package:chat_flutter/ui/atoms/my_profile_image.dart';
 import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
-import 'package:chat_flutter/ui/atoms/profile_image.dart';
+import 'package:chat_flutter/ui/atoms/circular_image.dart';
 import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/config/app_text_size.dart';
 
@@ -68,7 +69,7 @@ class _ProfileEditPage extends StatelessWidget {
                 );
               }
             },
-            child: const ProfileImage(
+            child: const MyProfileImage(
               size: 150,
             ),
           ),

--- a/lib/ui/pages/room/room_controller.dart
+++ b/lib/ui/pages/room/room_controller.dart
@@ -4,8 +4,8 @@ import 'package:chat_flutter/services/message_service.dart';
 import 'package:flutter/material.dart';
 
 class RoomController extends ChangeNotifier {
-  RoomController({this.messageService,this.authenticator}){
-    Future(()async{
+  RoomController({this.messageService, this.authenticator}) {
+    Future(() async {
       userId = await authenticator.getUid();
       notifyListeners();
     });
@@ -21,6 +21,6 @@ class RoomController extends ChangeNotifier {
   }
 
   Stream<List<Message>> messageList(String roomId) {
-    return messageService.getMessage(roomId,userId);
+    return messageService.getMessage(roomId, userId);
   }
 }

--- a/lib/ui/pages/sign_in/sign_in.dart
+++ b/lib/ui/pages/sign_in/sign_in.dart
@@ -3,6 +3,7 @@ import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/services/auth/authenticator.dart';
 import 'package:chat_flutter/ui/atoms/error_dialog.dart';
 import 'package:chat_flutter/ui/atoms/input_text_field.dart';
+import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:chat_flutter/ui/pages/sign_in/sign_in_controller.dart';
 import 'package:flutter/material.dart';
 
@@ -104,21 +105,26 @@ class SignInPage extends StatelessWidget {
                       borderRadius: BorderRadius.circular(AppRadius.xlarge),
                     ),
                     onPressed: () async {
-                      if(controller.email==null || controller.password==null){
-                        const String message = 'Emails and passwords should not be empty.';
+                      if (controller.email == null ||
+                          controller.password == null) {
+                        const String message =
+                            'Emails and passwords should not be empty.';
                         await showDialog<void>(
                             context: context,
                             builder: (context) => const ErrorDialog(message));
+                      } else {
+                        try {
+                          await controller.signIn();
+                          await Provider.of<ProfileController>(context,
+                                  listen: false)
+                              .getUserById();
+                          await Navigator.pushNamed(context, '/homePage');
+                        } on Exception catch (e) {
+                          await showDialog<void>(
+                              context: context,
+                              builder: (context) => ErrorDialog(e.toString()));
+                        }
                       }
-                      else{
-                      try {
-                        await controller.signIn();
-                        await Navigator.pushNamed(context, '/homePage');
-                      } on Exception catch (e) {
-                        await showDialog<void>(
-                            context: context,
-                            builder: (context) => ErrorDialog(e.toString()));
-                      }}
                     },
                   ),
                   const SizedBox(

--- a/lib/ui/pages/sign_up/sign_up.dart
+++ b/lib/ui/pages/sign_up/sign_up.dart
@@ -3,6 +3,7 @@ import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/services/auth/authenticator.dart';
 import 'package:chat_flutter/ui/atoms/error_dialog.dart';
 import 'package:chat_flutter/ui/atoms/input_text_field.dart';
+import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:chat_flutter/ui/pages/sign_up/sign_up_controller.dart';
 import 'package:flutter/material.dart';
 
@@ -21,7 +22,7 @@ class SignUpPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final controller = Provider.of<SignUpController>(context, listen: false);
+    final controller = Provider.of<SignUpController>(context);
     return Scaffold(
       backgroundColor: Colors.white70,
       body: Column(
@@ -105,21 +106,27 @@ class SignUpPage extends StatelessWidget {
                       borderRadius: BorderRadius.circular(AppRadius.xlarge),
                     ),
                     onPressed: () async {
-                      if(controller.name == null || controller.email==null || controller.password==null){
-                        const String message = 'Name,Email and password should not be empty.';
+                      if (controller.name == null ||
+                          controller.email == null ||
+                          controller.password == null) {
+                        const String message =
+                            'Name,Email and password should not be empty.';
                         await showDialog<void>(
                             context: context,
                             builder: (context) => const ErrorDialog(message));
+                      } else {
+                        try {
+                          await controller.signUp();
+                          await Provider.of<ProfileController>(context,
+                                  listen: false)
+                              .getUserById();
+                          await Navigator.pushNamed(context, '/homePage');
+                        } on Exception catch (e) {
+                          await showDialog<void>(
+                              context: context,
+                              builder: (context) => ErrorDialog(e.toString()));
+                        }
                       }
-                      else{
-                      try {
-                        await controller.signUp();
-                        await Navigator.pushNamed(context, '/homePage');
-                      } on Exception catch (e) {
-                        await showDialog<void>(
-                            context: context,
-                            builder: (context) => ErrorDialog(e.toString()));
-                      }}
                     },
                   ),
                   const SizedBox(


### PR DESCRIPTION
## 実装内容
画像周りの修正と起動画面切り替え実装

## 詳細内容
`ProfileImage`は`CircularImage`と`MyProfileImage`に分離。
（`ProfileController`を参照する・しないで大きな差があったため。）
`MyApp`前に`Wrapped`クラスを挟むことで、`Provider<ProfileController>`を`MyApp`内で使用可能に。

## 注意点
これで実装ほぼ終わり。
即マージなので、見る点は特になし。
