### PR TITLE
roomの並び変え実装

### DIFF
--- a/lib/model/room.dart
+++ b/lib/model/room.dart
@@ -4,15 +4,13 @@ class Room {
   String name;
   String imgUrl;
   List<String> members;
-  String lastMessage;
-  String sendTime;
+  Map<String, dynamic> lastMessage;
   Room({
     this.id,
     this.name,
     this.imgUrl,
     this.members,
     this.lastMessage,
-    this.sendTime,
   });
 
   factory Room.fromJson(Map<String, dynamic> json, String roomId) {
@@ -21,8 +19,7 @@ class Room {
       name: json['name'].toString(),
       imgUrl: json['imgUrl'].toString(),
       members: json['members'].cast<String>() as List<String>,
-      lastMessage: json['lastMessage'].toString(),
-      sendTime: json['sendTime'].toString(),
+      lastMessage: json['lastMessage'] as Map<String, dynamic>,
     );
   }
 }

--- a/lib/services/firebase_message_service.dart
+++ b/lib/services/firebase_message_service.dart
@@ -11,7 +11,7 @@ class FirebaseMessageService {
       'text': message.text,
       'createdAt': message.sendTime,
     };
-    final updateData = {'lastMessage': message.text};
+    final updateData = {'lastMessage': messageData};
     await _db
         .collection('message/v1/rooms/${message.roomId}/transcripts')
         .document()

--- a/lib/ui/molecules/talk/talk_page_app_bar.dart
+++ b/lib/ui/molecules/talk/talk_page_app_bar.dart
@@ -24,8 +24,9 @@ class TalkPageAppBar extends StatelessWidget with PreferredSizeWidget {
           icon: const Icon(
             Icons.refresh,
           ),
-          onPressed: () async{
-            await Provider.of<TalkController>(context,listen: false).getMyRoomList();
+          onPressed: () async {
+            await Provider.of<TalkController>(context, listen: false)
+                .getMyRoomList();
           },
         ),
         IconButton(

--- a/lib/ui/molecules/talk/talk_page_list_tile.dart
+++ b/lib/ui/molecules/talk/talk_page_list_tile.dart
@@ -1,89 +1,86 @@
 import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/config/app_text_size.dart';
 import 'package:chat_flutter/ui/atoms/circular_image.dart';
+import 'package:chat_flutter/util/common_func_util.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:chat_flutter/model/room.dart';
 
 class TalkPageListTile extends StatelessWidget {
-  final Future<Room> room;
+  final Room room;
 
   const TalkPageListTile(this.room);
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder(
-      future: room,
-      builder: (BuildContext context, AsyncSnapshot<Room> snapshot) {
-        if (!snapshot.hasData) {
-          return const SizedBox();
-        }
-        return FlatButton(
-          onPressed: () {
-            Navigator.pushNamed(
-              context,
-              '/roomPage',
-              arguments: snapshot.data,
-            );
-          },
-          child: SizedBox(
-            child: Padding(
-              padding: const EdgeInsets.all(AppSpace.small),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: <Widget>[
-                  CircularImage(size: 60, imgUrl: snapshot.data.imgUrl),
-                  const SizedBox(
-                    width: AppSpace.midium,
-                  ),
-                  SizedBox(
-                    height: 60,
-                    width: MediaQuery.of(context).size.width - 135,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+    return FlatButton(
+      onPressed: () {
+        Navigator.pushNamed(
+          context,
+          '/roomPage',
+          arguments: room,
+        );
+      },
+      child: SizedBox(
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpace.small),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              CircularImage(size: 60, imgUrl: room.imgUrl),
+              const SizedBox(
+                width: AppSpace.midium,
+              ),
+              SizedBox(
+                height: 60,
+                width: MediaQuery.of(context).size.width - 135,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: <Widget>[
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      crossAxisAlignment: CrossAxisAlignment.center,
                       children: <Widget>[
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: <Widget>[
-                            Flexible(
-                              child: Text(
-                                snapshot.data.name,
-                                style: const TextStyle(
-                                  fontSize: AppTextSize.midium,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                            Text(
-                              snapshot.data.sendTime,
-                              style: const TextStyle(
-                                fontSize: AppTextSize.xsmall,
-                                color: Colors.grey,
-                              ),
-                            ),
-                          ],
-                        ),
                         Flexible(
                           child: Text(
-                            snapshot.data.lastMessage,
+                            room.name,
                             style: const TextStyle(
-                              fontSize: AppTextSize.small,
-                              color: Colors.grey,
+                              fontSize: AppTextSize.midium,
+                              fontWeight: FontWeight.bold,
                             ),
                             overflow: TextOverflow.ellipsis,
                           ),
                         ),
+                        Text(
+                          CommonFuncUtil.dateTimeToString(
+                            (room.lastMessage['createdAt'] as Timestamp)
+                                .toDate(),
+                          ),
+                          style: const TextStyle(
+                            fontSize: AppTextSize.xsmall,
+                            color: Colors.grey,
+                          ),
+                        ),
                       ],
                     ),
-                  ),
-                ],
+                    Flexible(
+                      child: Text(
+                        room.lastMessage['text'].toString(),
+                        style: const TextStyle(
+                          fontSize: AppTextSize.small,
+                          color: Colors.grey,
+                        ),
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
+            ],
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 }

--- a/lib/ui/pages/create_room/create_room_controller.dart
+++ b/lib/ui/pages/create_room/create_room_controller.dart
@@ -5,6 +5,7 @@ import 'package:chat_flutter/model/storage_type.dart';
 import 'package:chat_flutter/services/auth/authenticator.dart';
 import 'package:chat_flutter/services/firebase_room_service.dart';
 import 'package:chat_flutter/services/firebase_storage_service.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:chat_flutter/model/user.dart';
 import 'package:image_picker/image_picker.dart';
@@ -18,7 +19,6 @@ class CreateRoomController with ChangeNotifier {
   final FirebaseRoomService _firebaseRoomService = FirebaseRoomService();
 
   Future<void> createRoom(List<User> members, String roomName) async {
-
     final List<String> memberIdList = members.map((member) {
       return member.id;
     }).toList();
@@ -33,14 +33,18 @@ class CreateRoomController with ChangeNotifier {
       members: memberIdList,
       // 初めはブランクで入れておく
       imgUrl: '',
-      lastMessage: '',
+      lastMessage: <String, dynamic>{
+        'text': '',
+        'createdAt': Timestamp.fromDate(DateTime.now()),
+      },
     );
 
     room.id = await _firebaseRoomService.setRoomData(room);
 
-    if(selectedImageFile!=null) {
+    if (selectedImageFile != null) {
       //roomIdで画像URLを作成する
-      room.imgUrl = await FirebaseStorageService().uploadImage(selectedImageFile, room.id, StorageType.room);
+      room.imgUrl = await FirebaseStorageService()
+          .uploadImage(selectedImageFile, room.id, StorageType.room);
       await FirebaseRoomService().updateRoomData(room);
     }
 

--- a/lib/ui/pages/room/room_controller.dart
+++ b/lib/ui/pages/room/room_controller.dart
@@ -31,9 +31,7 @@ class RoomController extends ChangeNotifier {
     return messageService.getMessage(roomId, userId);
   }
 
-
-
-  Future<void> changeRoomInfo(String name,File selectedImageFile) async {
+  Future<void> changeRoomInfo(String name, File selectedImageFile) async {
     room.name = name;
     if (selectedImageFile != null) {
       room.imgUrl = await FirebaseStorageService().uploadImage(

--- a/lib/ui/pages/talk/talk_controller.dart
+++ b/lib/ui/pages/talk/talk_controller.dart
@@ -14,9 +14,9 @@ class TalkController with ChangeNotifier {
   final FirebaseRoomService firebaseRoomService = FirebaseRoomService();
   Authenticator authenticator;
   String uid;
-  List<Future<Room>> roomList;
+  List<Room> roomList;
 
-  Future<void> getMyRoomList() async{
+  Future<void> getMyRoomList() async {
     roomList = await firebaseRoomService.getMyRoomList(uid);
     notifyListeners();
   }

--- a/lib/ui/pages/talk/talk_page.dart
+++ b/lib/ui/pages/talk/talk_page.dart
@@ -7,8 +7,7 @@ import 'package:provider/provider.dart';
 class TalkPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final List<Future<Room>> roomList =
-        Provider.of<TalkController>(context).roomList;
+    final List<Room> roomList = Provider.of<TalkController>(context).roomList;
     if (roomList == null) {
       return const Center(
         child: CircularProgressIndicator(),


### PR DESCRIPTION
## 実装内容
firestoreの`rooms/room_id/lastMessage`をStringではなく、Mapにして
```
{
  'text':String,
  'createdAt':TimeStamp
}
```
に変更
それに合わせて`Room`型の要素を修正し、並び替えにも対応した。

## 詳細内容
Future<List>で返さなくなったので、`FutureBuilder`の使用を中止した。

## 注意点
即マージなので特になし。
