### PR TITLE
既読機能の試行錯誤

### DIFF
--- a/lib/ui/molecules/message/message_list_item.dart
+++ b/lib/ui/molecules/message/message_list_item.dart
@@ -7,13 +7,27 @@ import 'package:chat_flutter/util/common_func_util.dart';
 import 'package:flutter/material.dart';
 
 import 'package:chat_flutter/config/app_text_size.dart';
+import 'package:provider/provider.dart';
 
 class MessageListItem extends StatelessWidget {
   const MessageListItem(this.message);
   final Message message;
+  int readPerson(List<DateTime> timeList) {
+    int count = 0;
+    final DateTime sendTime = message.sendTime;
+    timeList.forEach((time) {
+      if (time.compareTo(sendTime) >= 0) {
+        count++;
+      }
+    });
+    return count;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final timeList = Provider.of<List<DateTime>>(context);
     final FirebaseUserService firebaseUserService = FirebaseUserService();
+    final int readPersonNum = readPerson(timeList);
     return Padding(
       padding: const EdgeInsets.all(AppSpace.xsmall),
       child: Row(
@@ -24,10 +38,14 @@ class MessageListItem extends StatelessWidget {
           if (message.isMe)
             Column(
               children: <Widget>[
-                Text(
-                  (message.isRead) ? '既読' : '',
-                  style: const TextStyle(
-                    fontSize: AppTextSize.xsmall,
+                FutureBuilder(
+                  future:
+                      Future<void>.delayed(const Duration(milliseconds: 100)),
+                  builder: (context, snapshot) => Text(
+                    (readPersonNum > 1) ? '既読${readPersonNum - 1}' : '',
+                    style: const TextStyle(
+                      fontSize: AppTextSize.xsmall,
+                    ),
                   ),
                 ),
                 Text(

--- a/lib/ui/molecules/room/input_message_text_field.dart
+++ b/lib/ui/molecules/room/input_message_text_field.dart
@@ -12,7 +12,6 @@ class InputMessageTextField extends StatelessWidget {
     return Expanded(
       child: TextField(
         controller: roomTextController,
-        keyboardType: TextInputType.multiline,
         minLines: 1,
         maxLines: 4,
         decoration: InputDecoration(

--- a/lib/ui/pages/room/room_controller.dart
+++ b/lib/ui/pages/room/room_controller.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:chat_flutter/model/message.dart';
@@ -31,6 +32,15 @@ class RoomController extends ChangeNotifier {
     return messageService.getMessage(roomId, userId);
   }
 
+  Stream<List<DateTime>> lastReadTimeList(String roomId){
+    return FirebaseRoomService().getLastReadTimeList(roomId);
+  }
+
+  StreamSubscription<List<Message>> listenStream() {
+  return messageList(room.id).listen((event) {
+      //読んだ時間更新
+      FirebaseRoomService().updateLastReadTime(room.id, userId);
+    });}
   Future<void> changeRoomInfo(String name, File selectedImageFile) async {
     room.name = name;
     if (selectedImageFile != null) {
@@ -42,5 +52,10 @@ class RoomController extends ChangeNotifier {
     }
     await firebaseRoomService.updateRoomData(room);
     notifyListeners();
+  }
+  @override
+  void dispose(){
+    listenStream().cancel();
+    super.dispose();
   }
 }

--- a/lib/ui/pages/room/room_page.dart
+++ b/lib/ui/pages/room/room_page.dart
@@ -2,7 +2,6 @@ import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/model/message.dart';
 import 'package:chat_flutter/model/room.dart';
 import 'package:chat_flutter/services/auth/authenticator.dart';
-import 'package:chat_flutter/services/firebase_room_service.dart';
 import 'package:chat_flutter/services/message_service.dart';
 import 'package:chat_flutter/ui/molecules/message/message_list.dart';
 import 'package:chat_flutter/ui/molecules/room/input_message_text_field.dart';
@@ -54,7 +53,7 @@ class RoomPage extends StatelessWidget {
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           onPressed: () async{
-            await FirebaseRoomService().updateLastReadTime(room.id, roomController.userId);
+            roomController.dispose();
             Navigator.pop(context);
           },
         ),


### PR DESCRIPTION
がらくたが完成してしまった…機能していない。
**=>既読機能をなんとか実装完了**


## 実装内容
firestoreのroomの構成を変更した。
membersというListの値を削除し、membersコレクションを作った。
userIdごとにlastReadTimeというDateTimeを割り当て、最後にメッセージを呼んだ時間を保存する。

roomを閉じた時点でメッセージ変更の購読をキャンセルする。

## 詳細内容
機能自体はできているが、正しい実装方法なのかが不明。
（特にStreamの扱いはよくわかっていない。）

## 注意点
これまでに作成したroomは使用できないので注意してください。
（membersコレクションが存在していないためです。）
マージします。
